### PR TITLE
Update k8s registry references

### DIFF
--- a/internal/store/testutils_test.go
+++ b/internal/store/testutils_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 func TestSortLabels(t *testing.T) {
-	in := `kube_pod_container_info{container_id="docker://cd456",image="k8s.gcr.io/hyperkube2",container="container2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
-kube_pod_container_info{namespace="ns2",container="container3",container_id="docker://ef789",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",pod="pod2"} 1`
+	in := `kube_pod_container_info{container_id="docker://cd456",image="registry.k8s.io/hyperkube2",container="container2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
+kube_pod_container_info{namespace="ns2",container="container3",container_id="docker://ef789",image="registry.k8s.io/hyperkube3",image_id="docker://sha256:ccc",pod="pod2"} 1`
 
-	want := `kube_pod_container_info{container="container2",container_id="docker://cd456",image="k8s.gcr.io/hyperkube2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
-kube_pod_container_info{container="container3",container_id="docker://ef789",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",namespace="ns2",pod="pod2"} 1`
+	want := `kube_pod_container_info{container="container2",container_id="docker://cd456",image="registry.k8s.io/hyperkube2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
+kube_pod_container_info{container="container3",container_id="docker://ef789",image="registry.k8s.io/hyperkube3",image_id="docker://sha256:ccc",namespace="ns2",pod="pod2"} 1`
 
 	out := sortLabels(in)
 


### PR DESCRIPTION
Per https://github.com/kubernetes/k8s.io/issues/4780, Kubernetes is migrating its image registry to registry.k8s.io, and this repository is impacted.

We have to update the references of k8s.gcr.io to registry.k8s.io by April 3rd to remain up-to-date.

Here's a quick search for k8s.gcr.io on this repo. [[search result]](https://github.com/search?q=org%3Adapr%20%22k8s.gcr.io%22&type=code). Note that there may be other valid references (like, in the form of generated code, etc) which we have to be aware of.