### PR TITLE
fix: Adjusting to BroadcastJob type Never

### DIFF
--- a/internal/store/broadcastjob.go
+++ b/internal/store/broadcastjob.go
@@ -217,10 +217,14 @@ func broadcastJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			metric.Gauge,
 			"",
 			wrapBroadcastJobFunc(func(bj *v1alpha1.BroadcastJob) *metric.Family {
+				value := 0.0
+				if bj != nil && bj.Spec.CompletionPolicy.ActiveDeadlineSeconds != nil {
+					value = float64(*bj.Spec.CompletionPolicy.ActiveDeadlineSeconds)
+				}
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							Value: float64(*bj.Spec.CompletionPolicy.ActiveDeadlineSeconds),
+							Value: value,
 						},
 					},
 				}


### PR DESCRIPTION
Currently `BroadcastJob` with `type=Never` are making kruise-state-metrics to Terminate.
This small patch fixing the problem.